### PR TITLE
Inky phat support added and text color config options

### DIFF
--- a/python/service/music_detector.py
+++ b/python/service/music_detector.py
@@ -13,10 +13,10 @@ class MusicDetector:
     def __init__(self, recording_duration):
         try:
             from tflite_runtime.interpreter import Interpreter
-            self.interpreter = Interpreter('python/ml-model/1.tflite')
+            self.interpreter = Interpreter('ml-model/1.tflite')
         except ModuleNotFoundError:
             import tensorflow as tf
-            self.interpreter = tf.lite.Interpreter('python/ml-model/1.tflite')
+            self.interpreter = tf.lite.Interpreter('ml-model/1.tflite')
         self.down_sampled_rate = 16000
         self.raw_recording_sample_rate = 44100
         self.input_details = self.interpreter.get_input_details()
@@ -30,7 +30,7 @@ class MusicDetector:
         self.interpreter.allocate_tensors()
 
         self.class_names = None
-        with open('python/ml-model/yamnet_class_map.csv') as csv_file:
+        with open('ml-model/yamnet_class_map.csv') as csv_file:
             class_map_csv = io.StringIO(csv_file.read())
             self.class_names = [display_name for (class_index, mid, display_name) in csv.reader(class_map_csv)]
             self.class_names = self.class_names[1:]  # Skip header

--- a/python/shazampiEinkDisplay.py
+++ b/python/shazampiEinkDisplay.py
@@ -57,7 +57,7 @@ class ShazampiEinkDisplay:
         units = self.config.get('DEFAULT', 'units')
 
         # delay
-        if self.config.get('DEFAULT', 'delay_override'):
+        if self.config.has_option('DEFAULT', 'delay_override'):
             self.delay = int(self.config.get('DEFAULT', 'delay_override'))
 
         self.weather_service = WeatherService(api_key=openweathermap_api_key,
@@ -404,11 +404,10 @@ class ShazampiEinkDisplay:
                             if song_info:
                                 self.logger.debug("identified....")
                                 # update remaining time to wait for next re-identify
-                                if song_info.song_duration is None or song_info.offset is None or self.config.getint('DEFAULT', 'delay_override'):
-                                    if self.config.getint('DEFAULT', 'delay_override'):
-                                        song_end_duration_left = self.config.getint('DEFAULT', 'delay_override')
-                                    else:
-                                        song_end_duration_left = self.delay
+                                if self.config.has_option('DEFAULT', 'delay_override'):
+                                    song_end_duration_left = self.config.getint('DEFAULT', 'delay_override')
+                                elif song_info.song_duration is None or song_info.offset is None:
+                                    song_end_duration_left = self.delay
                                 else:
                                     song_end_duration_left = max(self.delay,
                                                                  song_info.song_duration-song_info.offset-self.recording_duration)

--- a/python/shazampiEinkDisplay.py
+++ b/python/shazampiEinkDisplay.py
@@ -55,6 +55,11 @@ class ShazampiEinkDisplay:
         openweathermap_api_key = self.config.get('DEFAULT', 'openweathermap_api_key')
         geo_coordinates = self.config.get('DEFAULT', 'geo_coordinates')
         units = self.config.get('DEFAULT', 'units')
+
+        # delay
+        if self.config.get('DEFAULT', 'delay_override'):
+            self.delay = int(self.config.get('DEFAULT', 'delay_override'))
+
         self.weather_service = WeatherService(api_key=openweathermap_api_key,
                                               geo_coordinates=geo_coordinates,
                                               units=units)
@@ -65,6 +70,12 @@ class ShazampiEinkDisplay:
         self.logger = self._init_logger()
         self.logger.info('Service instance created')
         if self.config.get('DEFAULT', 'model') == 'inky':
+            from inky.auto import auto
+            from inky.inky_uc8159 import CLEAN
+            self.inky_auto = auto
+            self.inky_clean = CLEAN
+            self.logger.info('Loading Pimoroni inky lib')
+        if self.config.get('DEFAULT', 'model') == 'inky-phat':
             from inky.auto import auto
             from inky.inky_uc8159 import CLEAN
             self.inky_auto = auto
@@ -109,7 +120,7 @@ class ShazampiEinkDisplay:
         t = ' '.join(text[:lo])  # this makes a string again
         w = int(draw.textlength(text=t, font=font))
         yield t, w
-        yield from self._break_fix(text[lo:], width, font, draw)
+        # yield from self._break_fix(text[lo:], width, font, draw)
 
     def _fit_text_top_down(self, img: Image, text: str, text_color: str, shadow_text_color: str, font: ImageFont,
                            y_offset: int, font_size: int, x_start_offset: int = 0, x_end_offset: int = 0,
@@ -170,6 +181,14 @@ class ShazampiEinkDisplay:
 
                     inky.show()
                     time.sleep(1.0)
+            if self.config.get('DEFAULT', 'model') == 'inky-phat':
+                inky = self.inky_auto()
+                for _ in range(2):
+                    for y in range(inky.height - 1):
+                        for x in range(inky.width - 1):
+                            inky.set_pixel(x, y, self.inky_clean)
+                    inky.show()
+                    time.sleep(1.0)
             if self.config.get('DEFAULT', 'model') == 'waveshare4':
                 epd = self.wave4.EPD()
                 epd.init()
@@ -214,6 +233,10 @@ class ShazampiEinkDisplay:
                 inky = self.inky_auto()
                 inky.set_image(image, saturation=saturation)
                 inky.show()
+            if self.config.get('DEFAULT', 'model') == 'inky-phat':
+                inky = self.inky_auto()
+                inky.set_image(image)
+                inky.show()
             if self.config.get('DEFAULT', 'model') == 'waveshare4':
                 epd = self.wave4.EPD()
                 epd.init()
@@ -241,6 +264,8 @@ class ShazampiEinkDisplay:
         offset_px_bottom = self.config.getint('DEFAULT', 'offset_px_bottom')
         offset_text_px_shadow = self.config.getint('DEFAULT', 'offset_text_px_shadow')
         text_direction = self.config.get('DEFAULT', 'text_direction')
+        text_color = self.config.get('DEFAULT', 'text_color')
+        text_shadow_color = self.config.get('DEFAULT', 'text_shadow_color')
         # The width and height of the background
         bg_w, bg_h = image.size
         if self.config.get('DEFAULT', 'background_mode') == 'fit':
@@ -276,29 +301,29 @@ class ShazampiEinkDisplay:
                                          self.config.getint('DEFAULT', 'font_size_artist'))
         if text_direction == 'top-down':
             title_position_y = album_cover_small_px + offset_px_top + 10
-            title_height = self._fit_text_top_down(img=image_new, text=title, text_color='white',
-                                                   shadow_text_color='black', font=font_title,
+            title_height = self._fit_text_top_down(img=image_new, text=title, text_color=text_color,
+                                                   shadow_text_color=text_shadow_color, font=font_title,
                                                    font_size=self.config.getint('DEFAULT', 'font_size_title'),
                                                    y_offset=title_position_y, x_start_offset=offset_px_left,
                                                    x_end_offset=offset_px_right,
                                                    offset_text_px_shadow=offset_text_px_shadow)
             artist_position_y = album_cover_small_px + offset_px_top + 10 + title_height
-            self._fit_text_top_down(img=image_new, text=artist, text_color='white', shadow_text_color='black',
+            self._fit_text_top_down(img=image_new, text=artist, text_color=text_color, shadow_text_color=text_shadow_color,
                                     font=font_artist, font_size=self.config.getint('DEFAULT', 'font_size_artist'),
                                     y_offset=artist_position_y, x_start_offset=offset_px_left,
                                     x_end_offset=offset_px_right, offset_text_px_shadow=offset_text_px_shadow)
         if text_direction == 'bottom-up':
             artist_position_y = self.config.getint('DEFAULT', 'height') - (
                     offset_px_bottom + self.config.getint('DEFAULT', 'font_size_artist'))
-            artist_height = self._fit_text_bottom_up(img=image_new, text=artist, text_color='white',
-                                                     shadow_text_color='black', font=font_artist,
+            artist_height = self._fit_text_bottom_up(img=image_new, text=artist, text_color=text_color,
+                                                     shadow_text_color=text_shadow_color, font=font_artist,
                                                      font_size=self.config.getint('DEFAULT', 'font_size_artist'),
                                                      y_offset=artist_position_y, x_start_offset=offset_px_left,
                                                      x_end_offset=offset_px_right,
                                                      offset_text_px_shadow=offset_text_px_shadow)
             title_position_y = self.config.getint('DEFAULT', 'height') - (
                     offset_px_bottom + self.config.getint('DEFAULT', 'font_size_title')) - artist_height
-            self._fit_text_bottom_up(img=image_new, text=title, text_color='white', shadow_text_color='black',
+            self._fit_text_bottom_up(img=image_new, text=title, text_color=text_color, shadow_text_color=text_shadow_color,
                                      font=font_title, font_size=self.config.getint('DEFAULT', 'font_size_title'),
                                      y_offset=title_position_y, x_start_offset=offset_px_left,
                                      x_end_offset=offset_px_right, offset_text_px_shadow=offset_text_px_shadow)
@@ -379,8 +404,11 @@ class ShazampiEinkDisplay:
                             if song_info:
                                 self.logger.debug("identified....")
                                 # update remaining time to wait for next re-identify
-                                if song_info.song_duration is None or song_info.offset is None:
-                                    song_end_duration_left = self.delay
+                                if song_info.song_duration is None or song_info.offset is None or self.config.getint('DEFAULT', 'delay_override'):
+                                    if self.config.getint('DEFAULT', 'delay_override'):
+                                        song_end_duration_left = self.config.getint('DEFAULT', 'delay_override')
+                                    else:
+                                        song_end_duration_left = self.delay
                                 else:
                                     song_end_duration_left = max(self.delay,
                                                                  song_info.song_duration-song_info.offset-self.recording_duration)

--- a/setup.sh
+++ b/setup.sh
@@ -122,7 +122,7 @@ echo "font_path = ${install_path}/resources/CircularStd-Bold.otf" >> ${install_p
 echo "font_size_title = 45" >> ${install_path}/config/eink_options.ini
 echo "font_size_artist = 35" >> ${install_path}/config/eink_options.ini
 echo "; Color of text for display readability" >> ${install_path}/config/eink_options.ini
-echo "; ie. inky phat (red, yellow, white)" >> ${install_path}/config/eink_options.ini
+echo "; ie. inky phat (red, yellow, white, black)" >> ${install_path}/config/eink_options.ini
 echo "text_color = white" >> ${install_path}/config/eink_options.ini
 echo "text_shadow_color = black" >> ${install_path}/config/eink_options.ini
 echo "offset_px_left = 20" >> ${install_path}/config/eink_options.ini

--- a/setup.sh
+++ b/setup.sh
@@ -56,10 +56,18 @@ fi
 echo
 echo "###### Display setup"
 PS3="Please select your Display Model: "
-options=("Pimoroni Inky Impression 4 (640x400)" "Waveshare 4.01inch ACeP 4 (640x400)" "Pimoroni Inky Impression 5.7 (600x448)" "Pimoroni Inky Impression 7.3 (800x480)")
+options=("Pimoroni Inky pHAT 2.13 (212x104)" "Pimoroni Inky Impression 4 (640x400)" "Waveshare 4.01inch ACeP 4 (640x400)" "Pimoroni Inky Impression 5.7 (600x448)" "Pimoroni Inky Impression 7.3 (800x480)")
 select opt in "${options[@]}"
 do
     case $opt in
+        "Pimoroni Inky Impression 4 (640x400)")
+            echo "[DEFAULT]" >> ${install_path}/config/eink_options.ini
+            echo "width = 212" >> ${install_path}/config/eink_options.ini
+            echo "height = 104" >> ${install_path}/config/eink_options.ini
+            echo "album_cover_small_px = 0" >> ${install_path}/config/eink_options.ini
+            echo "model = inky-phat" >> ${install_path}/config/eink_options.ini
+            break
+            ;;
         "Pimoroni Inky Impression 4 (640x400)")
             echo "[DEFAULT]" >> ${install_path}/config/eink_options.ini
             echo "width = 640" >> ${install_path}/config/eink_options.ini

--- a/setup.sh
+++ b/setup.sh
@@ -106,11 +106,16 @@ echo "album_cover_small = True" >> ${install_path}/config/eink_options.ini
 echo "; cleans the display every 20 picture" >> ${install_path}/config/eink_options.ini
 echo "; this takes ~60 seconds" >> ${install_path}/config/eink_options.ini
 echo "display_refresh_counter = 20" >> ${install_path}/config/eink_options.ini
+echo "delay_override = 20" >> ${install_path}/config/eink_options.ini
 echo "shazampi_log = ${install_path}/log/shazampi.log" >> ${install_path}/config/eink_options.ini
 echo "no_song_cover = ${install_path}/resources/default.jpg" >> ${install_path}/config/eink_options.ini
 echo "font_path = ${install_path}/resources/CircularStd-Bold.otf" >> ${install_path}/config/eink_options.ini
 echo "font_size_title = 45" >> ${install_path}/config/eink_options.ini
 echo "font_size_artist = 35" >> ${install_path}/config/eink_options.ini
+echo "; Color of text for display readability" >> ${install_path}/config/eink_options.ini
+echo "; ie. inky phat (red, yellow, white)" >> ${install_path}/config/eink_options.ini
+echo "text_color = white" >> ${install_path}/config/eink_options.ini
+echo "text_shadow_color = black" >> ${install_path}/config/eink_options.ini
 echo "offset_px_left = 20" >> ${install_path}/config/eink_options.ini
 echo "offset_px_right = 20" >> ${install_path}/config/eink_options.ini
 echo "offset_px_top = 0" >> ${install_path}/config/eink_options.ini

--- a/setup.sh
+++ b/setup.sh
@@ -114,7 +114,8 @@ echo "album_cover_small = True" >> ${install_path}/config/eink_options.ini
 echo "; cleans the display every 20 picture" >> ${install_path}/config/eink_options.ini
 echo "; this takes ~60 seconds" >> ${install_path}/config/eink_options.ini
 echo "display_refresh_counter = 20" >> ${install_path}/config/eink_options.ini
-echo "delay_override = 20" >> ${install_path}/config/eink_options.ini
+echo "; uncomment to override how long we wait after identifying a song" >> ${install_path}/config/eink_options.ini
+echo "; delay_override = 20" >> ${install_path}/config/eink_options.ini
 echo "shazampi_log = ${install_path}/log/shazampi.log" >> ${install_path}/config/eink_options.ini
 echo "no_song_cover = ${install_path}/resources/default.jpg" >> ${install_path}/config/eink_options.ini
 echo "font_path = ${install_path}/resources/CircularStd-Bold.otf" >> ${install_path}/config/eink_options.ini


### PR DESCRIPTION
Added a model config option for inky-phat with defaults I found to work reasonably well.

Because of the small display size I found changing the text color to be beneficial and added the ability to change text color in the config.

I also believe an override for the delay to identify again can be useful for some. I wanted to use this at music bingo where the songs don't play through to the end so a shorter delay was needed. It is initialized commented out and is an optional option to the config.

Here are my changes running on an Inky pHat Red on a Raspberry Pi 3 A+ (Red text, white shadow)
![IMG_5602](https://github.com/user-attachments/assets/4396c87f-a985-4fb7-959d-1c4332cce4b8)

This PR also fixes the path issue with the ml models. Issue #13 